### PR TITLE
Performance improvements for the Serial interface

### DIFF
--- a/large-hashable.cabal
+++ b/large-hashable.cabal
@@ -43,7 +43,8 @@ test-suite large-hashable-test
   type:                exitcode-stdio-1.0
   hs-source-dirs:      test
   main-is:             Main.hs
-  build-depends:       base, large-hashable, HTF, tasty-quickcheck, QuickCheck, text, bytes
+  build-depends:       base, large-hashable, HTF, tasty-quickcheck, QuickCheck, text, bytes,
+                       bytestring
   ghc-options:         -optc -O3 -fno-cse -threaded -rtsopts -with-rtsopts=-N
                        -Werror -W -fwarn-unused-imports -fwarn-unused-binds
                        -fwarn-unused-matches -fwarn-unused-do-bind -fwarn-wrong-do-bind

--- a/src/Data/LargeHashable/Class.hs
+++ b/src/Data/LargeHashable/Class.hs
@@ -103,8 +103,8 @@ instance LargeHashable Integer where
 
 {-# INLINE updateHashBool #-}
 updateHashBool :: Bool -> LH ()
-updateHashBool !True  = updateHash (1 :: Int)
-updateHashBool !False = updateHash (0 :: Int)
+updateHashBool !True  = updateHash (1 :: CULong)
+updateHashBool !False = updateHash (0 :: CULong)
 
 instance LargeHashable Bool where
     updateHash = updateHashBool
@@ -134,21 +134,21 @@ instance (LargeHashable a, LargeHashable b) => LargeHashable (a, b) where
 
 {-# INLINE updateHashMaybe #-}
 updateHashMaybe :: LargeHashable a => Maybe a -> LH ()
-updateHashMaybe !Nothing   = updateHash (0 :: Int)
+updateHashMaybe !Nothing   = updateHash (0 :: CULong)
 updateHashMaybe !(Just !x) = do
-    updateHash (1 :: Int)
+    updateHash (1 :: CULong)
     updateHash x
 
 instance LargeHashable a => LargeHashable (Maybe a) where
     updateHash = updateHashMaybe
 
 instance LargeHashable () where
-    updateHash () = updateHash (0 :: Int)
+    updateHash () = updateHash (0 :: CULong)
 
 instance LargeHashable Ordering where
-    updateHash EQ = updateHash (0  :: Int)
-    updateHash GT = updateHash (-1 :: Int)
-    updateHash LT = updateHash (1  :: Int)
+    updateHash EQ = updateHash (0  :: CULong)
+    updateHash GT = updateHash (-1 :: CULong)
+    updateHash LT = updateHash (1  :: CULong)
 
 instance (Integral a, LargeHashable a) => LargeHashable (Ratio a) where
     updateHash !i = do
@@ -166,10 +166,10 @@ instance LargeHashable' U1 where
 
 instance (LargeHashable' f, LargeHashable' g) => LargeHashable' (f :+: g) where
     updateHash' (L1 x) = do
-        updateHash (0 :: Int) -- is left
+        updateHash (0 :: CULong) -- is left
         updateHash' x
     updateHash' (R1 x) = do
-        updateHash (1 :: Int) -- is right
+        updateHash (1 :: CULong) -- is right
         updateHash' x
 
 instance (LargeHashable' f, LargeHashable' g) => LargeHashable' (f :*: g) where

--- a/src/Data/LargeHashable/Serial.hs
+++ b/src/Data/LargeHashable/Serial.hs
@@ -4,10 +4,6 @@ import Data.LargeHashable.Intern
 import Data.LargeHashable.Class
 import Data.Bytes.Put
 import Data.Bytes.Serial
-import Data.Word
-import Data.Bits
-import qualified Data.ByteString as B
-import qualified Data.ByteString.Lazy as BL
 
 serialLargeHash :: Serial a => HashAlgorithm -> a -> Hash
 serialLargeHash algo a = runLH algo $ serialize a
@@ -21,27 +17,13 @@ instance MonadPut LH where
     putWord64host = updateHash
     putWordhost = updateHash
 
-    putWord16le = updateHashle
-    putWord32le = updateHashle
-    putWord64le = updateHashle
+    putWord16le = updateHash
+    putWord32le = updateHash
+    putWord64le = updateHash
 
-    putWord16be = updateHashbe
-    putWord32be = updateHashbe
-    putWord64be = updateHashbe
+    putWord16be = updateHash
+    putWord32be = updateHash
+    putWord64be = updateHash
 
-    putByteString = B.foldl (\m w -> m >> updateHash w) (return ())
-    putLazyByteString = BL.foldl (\m w -> m >> updateHash w) (return ())
-
-updateHashbe :: (Bits a, Integral a, LargeHashable a) => a -> LH ()
-updateHashbe w = mapM_ updateHash $ splitInto8 w
-
-updateHashle :: (Bits a, Integral a, LargeHashable a) => a -> LH ()
-updateHashle w = let words = splitInto8 w
-                   in updateHash (last words) >> mapM_ updateHash (init words)
-
--- | Warning: Only works with unsigned Numbers
-splitInto8 :: (Bits a, Integral a) => a -> [Word8]
-splitInto8 i
-    | isSigned i = error "splitInto8 is only meant to be called with Words!"
-    | i == 0     = []
-    | otherwise  = fromIntegral (i .&. 0xff) : splitInto8 (shift i (-8))
+    putByteString = updateHash
+    putLazyByteString = updateHash

--- a/test/Data/LargeHashable/Tests/Class.hs
+++ b/test/Data/LargeHashable/Tests/Class.hs
@@ -7,7 +7,8 @@ import Data.LargeHashable
 import Data.LargeHashable.MD5
 import Data.LargeHashable.Tests.Helper
 import qualified Data.Text as T
-import Data.ByteString (ByteString ())
+import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
 
 prop_appendTextOk :: T.Text -> T.Text -> Bool
 prop_appendTextOk t1 t2 =
@@ -18,6 +19,16 @@ prop_appendListOk :: [Int] -> [Int] -> Bool
 prop_appendListOk l1 l2 =
     runMD5 (updateHash (l1 ++ l2)) /=
     runMD5 (updateHash l1 >> updateHash l2)
+
+prop_appendByteStringOk :: B.ByteString -> B.ByteString -> Bool
+prop_appendByteStringOk b1 b2 =
+    runMD5 (updateHash (b1 `B.append` b2)) /=
+    runMD5 (updateHash b1 >> updateHash b2)
+
+prop_appendLazyByteStringOk :: BL.ByteString -> BL.ByteString -> Bool
+prop_appendLazyByteStringOk b1 b2 =
+    runMD5 (updateHash (b1 `BL.append` b2)) /=
+    runMD5 (updateHash b1 >> updateHash b2)
 
 -- of course we can't fully prove uniqueness using
 -- properties and there is a small chance of collisions
@@ -36,5 +47,8 @@ prop_intUniqueness = generic_uniquenessProp
 prop_wordUniqueness :: Word -> Word -> Bool
 prop_wordUniqueness = generic_uniquenessProp
 
-prop_bytestringUniqueness :: ByteString -> ByteString -> Bool
+prop_bytestringUniqueness :: B.ByteString -> B.ByteString -> Bool
 prop_bytestringUniqueness = generic_uniquenessProp
+
+prop_lazyBytestringUniqueness :: BL.ByteString -> BL.ByteString -> Bool
+prop_lazyBytestringUniqueness = generic_uniquenessProp

--- a/test/Data/LargeHashable/Tests/Class.hs
+++ b/test/Data/LargeHashable/Tests/Class.hs
@@ -7,6 +7,7 @@ import Data.LargeHashable
 import Data.LargeHashable.MD5
 import Data.LargeHashable.Tests.Helper
 import qualified Data.Text as T
+import Data.ByteString (ByteString ())
 
 prop_appendTextOk :: T.Text -> T.Text -> Bool
 prop_appendTextOk t1 t2 =
@@ -34,3 +35,6 @@ prop_intUniqueness = generic_uniquenessProp
 
 prop_wordUniqueness :: Word -> Word -> Bool
 prop_wordUniqueness = generic_uniquenessProp
+
+prop_bytestringUniqueness :: ByteString -> ByteString -> Bool
+prop_bytestringUniqueness = generic_uniquenessProp

--- a/test/Data/LargeHashable/Tests/Helper.hs
+++ b/test/Data/LargeHashable/Tests/Helper.hs
@@ -4,6 +4,7 @@ module Data.LargeHashable.Tests.Helper where
 import Control.Monad
 import Test.QuickCheck
 import qualified Data.Text as T
+import qualified Data.ByteString as B
 import GHC.Generics
 import Data.LargeHashable
 import Data.Bytes.Serial
@@ -12,6 +13,11 @@ instance Arbitrary T.Text where
     arbitrary = liftM T.pack arbitrary
     shrink t =
         map T.pack (shrink (T.unpack t))
+
+instance Arbitrary B.ByteString where
+    arbitrary = liftM B.pack arbitrary
+    shrink t =
+        map B.pack (shrink (B.unpack t))
 
 data TestA
     = TestA

--- a/test/Data/LargeHashable/Tests/Helper.hs
+++ b/test/Data/LargeHashable/Tests/Helper.hs
@@ -5,6 +5,7 @@ import Control.Monad
 import Test.QuickCheck
 import qualified Data.Text as T
 import qualified Data.ByteString as B
+import qualified Data.ByteString.Lazy as BL
 import GHC.Generics
 import Data.LargeHashable
 import Data.Bytes.Serial
@@ -18,6 +19,11 @@ instance Arbitrary B.ByteString where
     arbitrary = liftM B.pack arbitrary
     shrink t =
         map B.pack (shrink (B.unpack t))
+
+instance Arbitrary BL.ByteString where
+    arbitrary = liftM BL.pack arbitrary
+    shrink t =
+        map BL.pack (shrink (BL.unpack t))
 
 data TestA
     = TestA


### PR DESCRIPTION
## Current performance

Standard interface:

    <<ghc: 95394160 bytes, 184 GCs, 3604803/9955528 avg/max bytes residency (5 samples), 24M in use, 0.002 INIT (0.001 elapsed), 0.149 MUT (0.092 elapsed), 0.422 GC (0.055 elapsed) :ghc>>
    real	0m0.144s
    user	0m0.261s
    sys	0m0.256s

Serial interface:

    <<ghc: 536192832 bytes, 1035 GCs, 4800418/10776056 avg/max bytes residency (6 samples), 35M in use, 0.002 INIT (0.001 elapsed), 0.494 MUT (0.251 elapsed), 0.694 GC (0.090 elapsed) :ghc>>
    real	0m0.317s
    user	0m0.612s
    sys	0m0.381s

The standard interface is about twice as fast as the serial interface.

## Possible performance improvements

Having looked at the `Serial` instances of `bytes` I can tell that those are pretty straightforward, so I see the `fromIntegral` calls are the major performance problem. That could be improved by implementing specific `hu_`-functions for the following types:

| Foreign | Haskell |
|---------|---------|
| CSChar  | Int8    |
| CUChar  | Word8   |
| CShort  | Int16   |
| CUShort | Word16  |
| CInt    | Int32   |
| CUInt   | Word32  |
| CLong   | Int64   |

Functions for the signed types are not needed, are they?