### PR TITLE
Update generics machinery to fully optimize

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ addons:
 # The different configurations we want to test. You could also do things like
 # change flags or use --stack-yaml to point to a different file.
 env:
+- LH_TRAVIS_STACK_ARGS="--stack-yaml stack-ghc80.yaml"
 - LH_TRAVIS_STACK_ARGS="--stack-yaml stack-ghc82.yaml"
 - LH_TRAVIS_STACK_ARGS="--stack-yaml stack-ghc84.yaml"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,9 +13,8 @@ addons:
 # The different configurations we want to test. You could also do things like
 # change flags or use --stack-yaml to point to a different file.
 env:
-- LH_TRAVIS_STACK_ARGS=""
-- LH_TRAVIS_STACK_ARGS="--resolver lts"
-- LH_TRAVIS_STACK_ARGS="--resolver nightly"
+- LH_TRAVIS_STACK_ARGS="--stack-yaml stack-ghc82.yaml"
+- LH_TRAVIS_STACK_ARGS="--stack-yaml stack-ghc84.yaml"
 
 before_install:
 - mkdir -p ~/.local/bin
@@ -23,8 +22,8 @@ before_install:
 - travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
 
 install:
-    - stack setup --no-terminal
-    - stack build --only-snapshot --no-terminal
+    - stack $LH_TRAVIS_STACK_ARGS setup --no-terminal
+    - stack $LH_TRAVIS_STACK_ARGS build --only-snapshot --no-terminal
 
 script:
     - stack $LH_TRAVIS_STACK_ARGS --no-terminal --install-ghc test --haddock --pedantic

--- a/large-hashable.cabal
+++ b/large-hashable.cabal
@@ -104,6 +104,7 @@ test-suite large-hashable-test
   default-language:    Haskell2010
   other-modules:       Data.LargeHashable.Tests.Class
                      , Data.LargeHashable.Tests.Helper
+                     , Data.LargeHashable.Tests.Inspection
                      , Data.LargeHashable.Tests.TH
                      , Data.LargeHashable.Tests.LargeWord
 

--- a/large-hashable.cabal
+++ b/large-hashable.cabal
@@ -95,6 +95,7 @@ test-suite large-hashable-test
                      , time
                      , unordered-containers
                      , vector
+                     , inspection-testing
   ghc-options:         -optc -O3 -fno-cse -threaded -rtsopts -with-rtsopts=-N
                        -W -fwarn-unused-imports -fwarn-unused-binds
                        -fwarn-unused-matches -fwarn-unused-do-bind -fwarn-wrong-do-bind

--- a/src/Data/LargeHashable/Class.hs
+++ b/src/Data/LargeHashable/Class.hs
@@ -396,7 +396,7 @@ instance (LargeHashable a, LargeHashable b) => LargeHashable (Either a b) where
     updateHash (Right !r) = updateHash (1 :: CULong) >> updateHash r
 
 instance LargeHashable () where
-    updateHash () = updateHash (0 :: CULong)
+    updateHash () = return ()
 
 instance LargeHashable Ordering where
     updateHash EQ = updateHash (0  :: CULong)
@@ -497,7 +497,7 @@ instance GenericLargeHashable V1 where
 
 instance GenericLargeHashable U1 where
     {-# INLINE updateHashGeneric #-}
-    updateHashGeneric _ = updateHash ()
+    updateHashGeneric U1 = updateHash ()
 
 instance (GenericLargeHashable f, GenericLargeHashable g) => GenericLargeHashable (f :*: g) where
     {-# INLINE updateHashGeneric #-}

--- a/src/Data/LargeHashable/Class.hs
+++ b/src/Data/LargeHashable/Class.hs
@@ -515,7 +515,7 @@ instance (GenericLargeHashable f) => GenericLargeHashable (M1 i t f) where
     updateHashGeneric x = updateHashGeneric (unM1 x)
 
 class GenericLargeHashableSum (f :: * -> *) where
-    updateHashGenericSum :: f p -> Word64 -> LH ()
+    updateHashGenericSum :: f p -> Int -> LH ()
 
 
 instance (GenericLargeHashable f, GenericLargeHashableSum g)

--- a/src/Data/LargeHashable/TH.hs
+++ b/src/Data/LargeHashable/TH.hs
@@ -196,6 +196,7 @@ patternForCon con = case con of
 #if MIN_VERSION_template_haskell(2,11,0)
               GadtC [n] types _ -> ConP n $ uniqueVarPats (length types)
               RecGadtC [n] varTypes _ -> ConP n $ uniqueVarPats (length varTypes)
+              _ -> error $ "Constructor not supported: "++show con
 #endif
     where uniqueVarPats n = take n . map (VarP . mkName) $ names
 

--- a/stack-ghc80.yaml
+++ b/stack-ghc80.yaml
@@ -1,0 +1,10 @@
+resolver: lts-9.21
+require-stack-version: ">= 1.0.0"
+
+packages:
+- '.'
+extra-deps:
+- git: https://github.com/nomeata/inspection-testing.git
+  commit: 0961c2620728fae6105a8d0c14c40a8e7729a3e8
+
+flags: {}

--- a/stack-ghc82.yaml
+++ b/stack-ghc82.yaml
@@ -1,0 +1,10 @@
+resolver: lts-11.13
+require-stack-version: ">= 1.0.0"
+
+packages:
+- '.'
+extra-deps:
+- git: https://github.com/nomeata/inspection-testing.git
+  commit: 0961c2620728fae6105a8d0c14c40a8e7729a3e8
+
+flags: {}

--- a/stack-ghc84.yaml
+++ b/stack-ghc84.yaml
@@ -1,0 +1,10 @@
+resolver: nightly-2018-06-11
+require-stack-version: ">= 1.0.0"
+
+packages:
+- '.'
+extra-deps:
+- git: https://github.com/nomeata/inspection-testing.git
+  commit: 0961c2620728fae6105a8d0c14c40a8e7729a3e8
+
+flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,10 +1,1 @@
-resolver: nightly-2018-06-11
-require-stack-version: ">= 1.0.0"
-
-packages:
-- '.'
-extra-deps:
-- git: https://github.com/nomeata/inspection-testing.git
-  commit: 0961c2620728fae6105a8d0c14c40a8e7729a3e8
-
-flags: {}
+stack-ghc84.yaml

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,32 +1,10 @@
-# For more information, see: https://github.com/commercialhaskell/stack/blob/master/doc/yaml_configuration.md
-
-# Specifies the GHC version and set of packages available (e.g., lts-3.5, nightly-2015-09-21, ghc-7.10.2)
-resolver: lts-6.0
-compiler-check: newer-minor
-compiler: ghc-7.10.3
+resolver: nightly-2018-06-11
 require-stack-version: ">= 1.0.0"
 
-# Local packages, usually specified by relative directory name
 packages:
 - '.'
+extra-deps:
+- git: https://github.com/nomeata/inspection-testing.git
+  commit: 0961c2620728fae6105a8d0c14c40a8e7729a3e8
 
-# Packages to be pulled from upstream that are not in the resolver (e.g., acme-missiles-0.3)
-extra-deps: []
-
-# Override default flag values for local packages and extra-deps
 flags: {}
-
-# Control whether we use the GHC we find on the path
-# system-ghc: true
-
-# Require a specific version of stack, using version ranges
-# require-stack-version: -any # Default
-# require-stack-version: >= 0.1.4.0
-
-# Override the architecture used by stack, especially useful on Windows
-# arch: i386
-# arch: x86_64
-
-# Extra directories used by stack for building
-# extra-include-dirs: [/path/to/dir]
-# extra-lib-dirs: [/path/to/dir]

--- a/test/Data/LargeHashable/Tests/Inspection.hs
+++ b/test/Data/LargeHashable/Tests/Inspection.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE TemplateHaskell   #-}
+{-# LANGUAGE DeriveGeneric     #-}
+{-# OPTIONS_GHC -F -pgmF htfpp #-}
+{-# OPTIONS_GHC -O -fplugin Test.Inspection.Plugin #-}
+module Data.LargeHashable.Tests.Inspection where
+
+import Test.Framework hiding ((===), Failure, Success)
+import Test.Inspection
+
+import Data.LargeHashable
+import Data.LargeHashable.Tests.Helper
+import Data.LargeHashable.Class
+import GHC.Generics
+
+genericUpdateHashTestA :: TestA -> LH ()
+genericUpdateHashTestA = genericUpdateHash
+
+test_genericProductGetsOptimized :: IO ()
+test_genericProductGetsOptimized =
+    case $(inspectTest (hasNoGenerics 'genericUpdateHashTestA)) of
+      Success _ -> return ()
+      Failure e -> assertFailure e
+
+data SumTest
+    = A Int
+    | B Char
+    | C Integer
+    | D (Either Int Char)
+    deriving (Generic)
+
+genericUpdateHashSum :: SumTest -> LH ()
+genericUpdateHashSum = genericUpdateHash
+
+test_genericSumGetsOptimized :: IO ()
+test_genericSumGetsOptimized =
+    case $(inspectTest (hasNoGenerics 'genericUpdateHashSum)) of
+      Success _ -> return ()
+      Failure e -> assertFailure e
+
+data SopTest
+    = A2 Char Int Bool
+    | B2 SopTest Int Bool SopTest
+    | C2 SopTest SopTest
+    | D2 (Either Int Char) SopTest
+    deriving (Generic)
+
+genericUpdateHashSop :: SumTest -> LH ()
+genericUpdateHashSop = genericUpdateHash
+
+test_genericSumOfProductsGetsOptimized :: IO ()
+test_genericSumOfProductsGetsOptimized =
+    case $(inspectTest (hasNoGenerics 'genericUpdateHashSop)) of
+      Success _ -> return ()
+      Failure e -> assertFailure e

--- a/test/Data/LargeHashable/Tests/Inspection.hs
+++ b/test/Data/LargeHashable/Tests/Inspection.hs
@@ -52,3 +52,32 @@ test_genericSumOfProductsGetsOptimized =
     case $(inspectTest (hasNoGenerics 'genericUpdateHashSop)) of
       Success _ -> return ()
       Failure e -> assertFailure e
+
+data UnitTest = UnitTest deriving (Generic)
+
+genericUpdateHashUnitType :: UnitTest -> LH ()
+genericUpdateHashUnitType = genericUpdateHash
+
+unitTypeReturn :: UnitTest -> LH ()
+unitTypeReturn UnitTest = return ()
+
+test_genericUnitHashIsNoop :: IO ()
+test_genericUnitHashIsNoop =
+    case $(inspectTest ('genericUpdateHashUnitType === 'unitTypeReturn)) of
+      Success _ -> return ()
+      Failure e -> assertFailure e
+
+updateHashHaskellUnit :: () -> LH ()
+updateHashHaskellUnit () =
+    -- I have to do this twice for inlining to work
+    do updateHash ()
+       updateHash ()
+
+haskellUnitReturn :: () -> LH ()
+haskellUnitReturn () = return ()
+
+test_haskellUnitHashIsNoop :: IO ()
+test_haskellUnitHashIsNoop =
+    case $(inspectTest ('updateHashHaskellUnit === 'haskellUnitReturn)) of
+      Success _ -> return ()
+      Failure e -> assertFailure e

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -5,6 +5,7 @@ import Test.Framework
 
 -- In Emacs sort block with M-x sort-lines
 import {-@ HTF_TESTS @-} Data.LargeHashable.Tests.Class
+import {-@ HTF_TESTS @-} Data.LargeHashable.Tests.Inspection
 import {-@ HTF_TESTS @-} Data.LargeHashable.Tests.LargeWord
 import {-@ HTF_TESTS @-} Data.LargeHashable.Tests.TH
 


### PR DESCRIPTION
Now the generics-version supasses the template-haskell version. That means the template-haskell-veriosn should probably be fixed as well.