### PR TITLE
Support aeson 2.0

### DIFF
--- a/large-hashable.nix
+++ b/large-hashable.nix
@@ -1,22 +1,29 @@
-{ mkDerivation, aeson, base, base16-bytestring, bytes, bytestring
-, containers, hashable, HTF, QuickCheck, scientific, stdenv, strict
-, template-haskell, text, time, transformers, unordered-containers
-, utf8-light, vector, void
+{ mkDerivation, aeson, base, base16-bytestring, byteable, bytes
+, bytestring, cereal, containers, criterion, cryptohash, cryptonite
+, deepseq, hashable, HTF, inspection-testing, lib, memory
+, QuickCheck, safecopy, scientific, strict, template-haskell, text
+, time, transformers, unordered-containers, utf8-light, vector
+, void
 }:
 mkDerivation {
   pname = "large-hashable";
-  version = "0.1.0.3";
+  version = "0.1.0.4";
   src = ./.;
   libraryHaskellDepends = [
-    aeson base base16-bytestring bytes bytestring containers scientific
-    strict template-haskell text time transformers unordered-containers
-    utf8-light vector void
+    aeson base base16-bytestring bytes bytestring containers cryptonite
+    memory scientific strict template-haskell text time transformers
+    unordered-containers utf8-light vector void
   ];
   testHaskellDepends = [
-    aeson base bytes bytestring containers hashable HTF QuickCheck
-    scientific strict text time unordered-containers vector
+    aeson base bytes bytestring containers hashable HTF
+    inspection-testing QuickCheck scientific strict text time
+    unordered-containers vector
+  ];
+  benchmarkHaskellDepends = [
+    base base16-bytestring byteable bytes bytestring cereal criterion
+    cryptohash deepseq safecopy text transformers
   ];
   homepage = "https://github.com/factisresearch/large-hashable";
   description = "Efficiently hash (large) Haskell values";
-  license = stdenv.lib.licenses.bsd3;
+  license = lib.licenses.bsd3;
 }

--- a/test/Data/LargeHashable/Tests/Helper.hs
+++ b/test/Data/LargeHashable/Tests/Helper.hs
@@ -15,18 +15,21 @@ import Data.Time.Clock.TAI
 import Data.Time.LocalTime
 import GHC.Generics
 import Test.QuickCheck
-import qualified Data.Aeson as J
 import qualified Data.ByteString as B
 import qualified Data.ByteString.Lazy as BL
 import qualified Data.ByteString.Short as BS
 import qualified Data.HashMap.Lazy as HML
-import qualified Data.HashMap.Strict as HM
 import qualified Data.HashSet as HS
 import qualified Data.Scientific as Sci
 import qualified Data.Strict.Tuple as Tuple
 import qualified Data.Text as T
 import qualified Data.Text.Lazy as TL
 import qualified Data.Vector as V
+
+#if !MIN_VERSION_aeson(2,0,0)
+import qualified Data.Aeson as J
+import qualified Data.HashMap.Strict as HM
+#endif
 
 #if !MIN_VERSION_QuickCheck(2,8,2)
 -- keep imports in alphabetic order (in Emacs, use "M-x sort-lines")
@@ -61,6 +64,7 @@ instance Arbitrary Sci.Scientific where
         liftM2 Sci.scientific arbitrary arbitrary
     shrink = shrinkRealFrac
 
+#if !MIN_VERSION_aeson(2,0,0)
 instance Arbitrary J.Value where
     arbitrary = sized arbitraryJsonValue
         where
@@ -103,6 +107,7 @@ instance Arbitrary J.Value where
               map J.Number (shrink n)
           J.Bool _ -> []
           J.Null -> []
+#endif
 
 instance (Eq k, Hashable k, Arbitrary k, Arbitrary a) => Arbitrary (HML.HashMap k a) where
     arbitrary = fmap HML.fromList arbitrary


### PR DESCRIPTION
aeson 2.0 needs us to support the more generic KeyMap and Key instead of
a plain HashMap. Additionally, we need to drop the orphan Arbitrary
instance in the test suite which is now provided by upstream.

Tested with GHC 8.10.7 / Stackage LTS 18 and GHC 9.0.2 / Stackage
Nightly.